### PR TITLE
Игнорирование топиков, прописанных в "Путь (write):"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/modules/mqtt/mqtt_edit.inc.php
+++ b/modules/mqtt/mqtt_edit.inc.php
@@ -33,6 +33,9 @@
 
    global $path_write;
    $rec['PATH_WRITE']=trim($path_write);
+   
+   global $disp_flag;
+   $rec['DISP_FLAG']=(int)$disp_flag;
 
    global $qos;
    $rec['QOS']=(int)$qos;

--- a/templates/mqtt/mqtt_edit.html
+++ b/templates/mqtt/mqtt_edit.html
@@ -56,6 +56,16 @@
 
 <div class="form-group">
  <label class="control-label">
+ Not display write path in list:
+ </label>
+ <div class="controls">
+  <input type="hidden" name="disp_flag" value="0"> <!-- value for unchecked checkbox -->
+  <input type="checkbox" name="disp_flag" value="1" [#if DISP_FLAG="1"#]checked[#endif#]>
+ </div>
+</div>
+
+<div class="form-group">
+ <label class="control-label">
  QoS:
  (<#LANG_OPTIONAL#>)
  </label>


### PR DESCRIPTION
Данный запрос на добавление содержит следующие изменения:
1. Добавлена галка "Not display write path in list" в странице mqtt_edit.html
2. Внесен в MySQL таблицу mqtt новый столбец DISP_FLAG, который хранит состояние галки, индивидуальное для каждого топика в списке.
3. Изменен механизм приема и обработки сообщений с учетом этой галочки.
3.1. Механизм работы следующий:
      А) При получении нового сообщения, производится запрос в базу с поиском пути в столбце PATH таблицы mqtt.
      Б) Если топик не найден в PATH, производится новый запрос в базу с поиском пути в столбце PATH_WRITE таблицы MQTT.
      Г) Если топик не найден в PATH_WRITE, производится вставка новой записи в таблицу mqtt.
      Д) Если топик найден в PATH_WRITE, то проверяется состояние галочки в столбце DISP_FLAG.
      Е) Если галка стоит, то сообщение игнорируется и производится выход из метода processMessage.
      Ж) Если галка не стоит, то производится вставка новой записи в таблицу mqtt.
      З) Если по пункту Б топик был найден в PATH, то производится обновление данных текущего топика.

Данные изменения были созданы с целью наведения порядка в списке топиков, так как в некоторых случаях, публикации данных в путях WRITE другими устройствами, заполняют список ненужными топиками, даже если подписка MajorDomo на эти топики не нужна.

Если нужно подписать MajorDomo на топик WRITE, то достаточно не ставить галку там, где этот топик прописан как write, либо добавить топик в список вручную. В этом случае значение галки в другом топике (где топик прописан как write) будет игнорироваться, так как топик будет найден при первом же запросе в базу при поиске в столбце PATH.
