### PR TITLE
Fixing processMassage()

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -231,6 +231,9 @@ function run() {
      $rec['TITLE']=$path;
      $rec['VALUE']=$value.'';
      $rec['UPDATED']=date('Y-m-d H:i:s');
+	 $rec['LOCATION_ID']=0;
+	 $rec['LINKED_OBJECT']='';
+	 $rec['LINKED_PROPERTY']='';
      $rec['ID']=null;
      SQLInsert('mqtt', $rec);
    }else{

--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -226,15 +226,20 @@ function run() {
          return 0; /* ignore message if flag checked */
        }
      }
-     /* Insert new record in db */
-     $rec['PATH']=$path;
-     $rec['TITLE']=$path;
-     $rec['VALUE']=$value.'';
-     $rec['UPDATED']=date('Y-m-d H:i:s');
+     /* Init new record */
+	 $rec['ID']=null;
+	 $rec['TITLE']=$path;
 	 $rec['LOCATION_ID']=0;
+	 $rec['UPDATED']=date('Y-m-d H:i:s');
+	 $rec['VALUE']=$value.'';
+	 $rec['PATH']=$path;
+	 $rec['PATH_WRITE']='';
 	 $rec['LINKED_OBJECT']='';
 	 $rec['LINKED_PROPERTY']='';
-     $rec['ID']=null;
+	 $rec['QOS']=0;
+	 $rec['RETAIN']=0;
+	 $rec['DISP_FLAG']=0;
+	 /* Insert new record in db */
      SQLInsert('mqtt', $rec);
    }else{
      /* Update values in db */

--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -125,6 +125,51 @@ function run() {
     SQLExec ( $sqlQuery );   
   }
 
+    function pathToTree($array){
+        $tree = array();
+        foreach($array AS $item) {
+            $pathIds = explode("/", ltrim($item["PATH"], "/") .'/'. $item["ID"]);
+            $current = &$tree;
+            $cp='';
+            foreach($pathIds AS $id) {
+                if(!isset($current["CHILDS"][$id])) {
+                    $current["CHILDS"][$id] = array('CP'=>$cp);
+                }
+                $current = &$current["CHILDS"][$id];
+                if($id == $item["ID"]) {
+                    $current = $item;
+                }
+            }
+        }
+        return ($this->childsToArray($tree['CHILDS']));
+    }
+
+    function childsToArray($items,$prev_path='') {
+        $res=array();
+        foreach($items as $k=>$v) {  
+            if (!$v['PATH']) {
+                $v['TITLE']=$k.' '.$v['CP'];
+                $pp = $k; 
+            }
+            else {
+                $v['TITLE'] = '';
+                $pp = '';
+            }
+            if (isset($v['CHILDS'])) {
+                $items=$this->childsToArray($v['CHILDS'],$prev_path ? $prev_path.'/'.$pp : $pp);
+                if (count($items)==1) {
+                    $v=$items[0];     
+                    $v['TITLE'] = $pp.($v['TITLE'] ? '/'.$v['TITLE'] : '');
+                } else {
+                    $v['RESULT']=$items;
+                }
+                unset($v['CHILDS']);
+            }
+            $res[]=$v;
+        }
+        return $res;
+    }
+
 /**
 * Title
 *
@@ -333,8 +378,21 @@ function admin(&$out) {
    $this->delete_mqtt($this->id);
    $this->redirect("?");
   }
+     if ($this->view_mode=='clear_trash') {
+         $this->clear_trash();
+         $this->redirect("?");
+     }
  }
 }
+
+function clear_trash() {
+    $res=SQLSelect("SELECT ID FROM mqtt WHERE LINKED_OBJECT='' AND LINKED_PROPERTY=''");
+    $total = count($res);
+    for ($i=0;$i<$total;$i++) {
+        $this->delete_mqtt($res[$i]['ID']);
+    }
+}
+
 /**
 * FrontEnd
 *
@@ -343,6 +401,22 @@ function admin(&$out) {
 * @access public
 */
 function usual(&$out) {
+    if ($this->ajax) {
+        global $op;
+        $result=array();
+        if ($op=='getvalues') {
+            global $ids;
+            if (!is_array($ids)) {
+                $ids=array(0);
+            } else {
+                $ids[]=0;
+            }
+            $data=SQLSelect("SELECT ID,VALUE FROM mqtt WHERE ID IN (".implode(',',$ids).")");
+            $result['DATA']=$data;
+        }
+        echo json_encode($result);
+        exit;
+    }
  $this->admin($out);
 }
 /**

--- a/modules/mqtt/mqtt_search.inc.php
+++ b/modules/mqtt/mqtt_search.inc.php
@@ -52,19 +52,41 @@
   //if (!$sortby_mqtt) $sortby_mqtt="ID DESC";
   $sortby_mqtt="UPDATED DESC";
   $out['SORTBY']=$sortby_mqtt;
+
+  global $tree;
+  if (!isset($tree)) {
+   $tree=(int)$session->data['MQTT_TREE_VIEW'];
+  } else {
+   $session->data['MQTT_TREE_VIEW']=$tree;
+  }
+  if ($tree) {
+   $out['TREE']=1;
+  }
+
   // SEARCH RESULTS
+  if ($out['TREE']) {
+   $sortby_mqtt='PATH';
+  }
   $res=SQLSelect("SELECT * FROM mqtt WHERE $qry ORDER BY ".$sortby_mqtt);
   if ($res[0]['ID']) {
-   paging($res, 50, $out); // search result paging
-   colorizeArray($res);
+   if (!$out['TREE']) {
+    paging($res, 50, $out); // search result paging
+   }
    $total=count($res);
    for($i=0;$i<$total;$i++) {
     // some action for every record if required
-    $tmp=explode(' ', $res[$i]['UPDATED']);
-    $res[$i]['UPDATED']=fromDBDate($tmp[0])." ".$tmp[1];
+    //$tmp=explode(' ', $res[$i]['UPDATED']);
+    //$res[$i]['UPDATED']=fromDBDate($tmp[0])." ".$tmp[1];
+    if ($res[$i]['TITLE']==$res[$i]['PATH'] && !$out['TREE']) $res[$i]['PATH']='';
    }
    $out['RESULT']=$res;
+
+   if ($out['TREE']) {
+    $out['RESULT']=$this->pathToTree($res);
+   }
+
   }
+
 
   $out['LOCATIONS']=SQLSelect("SELECT * FROM locations ORDER BY TITLE");
 

--- a/templates/mqtt/mqtt_search_admin.html
+++ b/templates/mqtt/mqtt_search_admin.html
@@ -70,34 +70,39 @@
 </form>
 </div>
 
-<br>
-<!-- table mqtt search -->
-<p>
-<a href="?view_mode=edit_mqtt" class="btn btn-default"><i class="glyphicon glyphicon-plus"></i> <#LANG_ADD_NEW_RECORD#></a>
-</p>
-
 &nbsp;
 
 <form action="?" method="get" name="frmFilter">
-<table border="0">
- <tr>
-  <td valign="top"><input type="text" name="title" value="<#TITLE#>" class="form-control" placeholder="<#LANG_SEARCH#>"></td>
-  <td>
+ <div class="row">
+
+  <div class="col-md-3">
+<input type="text" name="title" value="<#TITLE#>" class="form-control" placeholder="<#LANG_SEARCH#>">
+  </div>
+  <div class="col-md-3">
   <select class="form-control" name="location_id">
    <option value="0"><#LANG_FILTER_BY_LOCATION#> (<#LANG_ALL#>)
    [#begin LOCATIONS#]
    <option value="[#ID#]"[#if ID="<#LOCATION_ID#>"#] selected[#endif#]>[#TITLE#]
    [#end LOCATIONS#]
   </select>
-  </td>
-  <td valign="top">
+  </div>
+  <div class="col-md-2">
     <input type="submit" name="submit" value="<#LANG_SEARCH#>" class="btn btn-default">
-  </td>
- </tr>
-</table>
+  </div>
+  <div class="col-md-2">
+   [#if TREE="1"#]
+   <a href="?tree=0" class="btn btn-default"><#LANG_LIST_VIEW#></a>
+   [#else#]
+   <a href="?tree=1" class="btn btn-default"><#LANG_TREE_VIEW#></a>
+   [#endif#]
+  </div>
+  <div class="col-md-2">
+   <a href="?view_mode=edit_mqtt" class="btn btn-default"><i class="glyphicon glyphicon-plus"></i> <#LANG_ADD#></a>
+   <a href="?view_mode=clear_trash" class="btn btn-default" title="Delete not linked topics." onclick="return confirm('<#LANG_ARE_YOU_SURE#>');"><i class="glyphicon glyphicon-floppy-remove"></i> <#LANG_OPTIMIZE#></a>
+  </div>
+ </div>
 </form>
-
-
+&nbsp;
 
 <!-- results -->
 [#if RESULT#]
@@ -115,7 +120,19 @@
 [#endif PAGES#]
 <!-- / paging -->
 <!-- search results (list) -->
-<form action="?" method="post" name="frmList_mqtt" style="padding:0px" class="form">
+[#if TREE="1"#]
+<ul>
+ [#begin RESULT#]
+ <li style="list-style-type: none">
+  [#if ID!=""#]
+  [#if TITLE!=""#]<b>&bull;</b>&nbsp;[#endif#]<a href="?view_mode=edit_mqtt&id=[#ID#]" title="[#PATH#]">[#if TITLE=""#]<b>&bull;</b>&nbsp;[#else#][#TITLE#][#endif#]</a> <span id="mqtt[#ID#]" class="mqtt_value">[#VALUE#]</span>
+  [#if LINKED_OBJECT!=""#]<i>([#LINKED_OBJECT#].[#LINKED_PROPERTY#])</i>[#endif LINKED_OBJECT#]
+  [#else#]<b>&bull;&nbsp;[#TITLE#]</b>[#endif#]
+  [#if RESULT#]<ul>[#tree RESULT#]</ul>[#endif RESULT#]
+ </li>
+ [#end RESULT#]
+</ul>
+[#else TREE#]
 <table   class="table table-stripped">
 <thead>
 <tr>
@@ -135,14 +152,12 @@
 </thead>
 <tbody>
 [#begin RESULT#]
-<tr class="hover_btn2">
- <td
-  >
+<tr>
+ <td>
   <b>
    [#TITLE#]
-  </a></b>
-  <br>
-  [#PATH#]
+  </b>[#if PATH!=""#]<br>[#PATH#][#endif#]
+  [#if LINKED_OBJECT!=""#]<br/><i>[#LINKED_OBJECT#].[#LINKED_PROPERTY#]</i>[#endif LINKED_OBJECT#]
  </td>
  <td
    >
@@ -154,11 +169,7 @@
  </td>
  <td
  >
-  [#if VALUE!=""#]
-   [#VALUE#]
-  [#else#]
-   &nbsp;
-  [#endif#]
+  <span id="mqtt[#ID#]" class="mqtt_value">[#VALUE#]</span>
   [#if LINKED_OBJECT!=""#]([#LINKED_OBJECT#].[#LINKED_PROPERTY#])[#endif LINKED_OBJECT#]
  </td>
  <td width="1%" nowrap>
@@ -173,9 +184,7 @@
 [#end RESULT#]
 </tbody>
 </table>
-<input type="hidden" name="data_source" value="<#DATA_SOURCE#>">
-<input type="hidden" name="view_mode" value="multiple_mqtt">
-</form>
+[#endif TREE#]
 <!-- / search results (list) -->
 <!-- paging -->
 [#if PAGES#]
@@ -196,4 +205,33 @@
 </p>
 [#endif RESULT#]
 <!-- / results -->
+<script type="text/javascript">
+ var valuesUpdateTimeout=0;
+ function getLatestValues() {
+  clearTimeout(valuesUpdateTimeout);
+  var ids='';
+  $('.mqtt_value').each(function () {
+   ids+='ids[]='+this.id.replace('mqtt','')+'&';
+  });
+  var url='/ajax/mqtt.html?op=getvalues&'+ids;
+  $.ajax({
+   url: url
+  }).done(function(data) {
+   var obj=jQuery.parseJSON(data);
+   if (obj.DATA.length>0) {
+    for(var i=0;i<obj.DATA.length;i++) {
+     var item_id=obj.DATA[i].ID;
+     var value = obj.DATA[i].VALUE;
+     var oldValue=$('#mqtt'+item_id).html();
+     $('#mqtt'+item_id).html(value);
+     if (value!=oldValue) {
+      $("#mqtt"+item_id).fadeTo(100, 0.1).fadeTo(200, 1.0);
+     }
+    }
+   }
+   valuesUpdateTimeout = setTimeout('getLatestValues()',2000);
+  });
+ }
+ valuesUpdateTimeout = setTimeout('getLatestValues()',2000);
+</script>
 


### PR DESCRIPTION
1. Обновление модуля из репозитория sergejey/majordomo-mqtt (27/01/2018)

2. Обнаружился баг при следующих условиях:
Если запись найдена в PATH_WRITE и флаг DISP_FLAG в этой записи сброшен в '0', то при создании новой записи, в ней оказывается часть данных от предыдущего запроса. Таким образом, в общем списке появляются новые топики с привязанными объектами, с которыми по логике они не должны быть связаны (в новых записях автоматически заполненными должны быть только названия (TITLE), пути (PATH) и сами данные (VALUE), остальное должно быть заполнено либо данными по умолчанию (QOS, RETAIN, DISP_FLAG, LOCATION_ID) либо оставаться пустым (LINKED_OBJECT, LINKED_PROPRTY, PATH_WRITE).
Исправление: Полная инициализация всех полей переменной $rec перед выполнением SQLInsert() с целью "затирания" старых данных, оставшихся от предыдущего запроса.

1. Module update from sergejey/majordomo-mqtt (27/01/2018)

2. Bug:
If record found in column "PATH_WRITE" and flag "DISP_FLAG" in finded record is cleared, then parts of data (linked object, property and other) will be copied to new record.
Bugfix: 
Init all data in $rec variable before call SQLInsert().