### PR TITLE
fix incorrect variable name in processMessage

### DIFF
--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -342,7 +342,7 @@ class mqtt extends module
 
                 setGlobal($rec['LINKED_OBJECT'] . '.' . $rec['LINKED_PROPERTY'], $value, array('mqtt' => '0'));
             }
-            if ($rec['LINKED_OBJECT'] && $cmd_rec['LINKED_METHOD']) {
+            if ($rec['LINKED_OBJECT'] && $rec['LINKED_METHOD']) {
                 callMethodSafe($rec['LINKED_OBJECT'] . '.' . $rec['LINKED_METHOD'], $rec['VALUE']);
             }
 


### PR DESCRIPTION
Исправил ошибку, из-за которой не вызывались связанные методы. 