### PR TITLE
Fix "Data too long" error.

### DIFF
--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -673,7 +673,7 @@ class mqtt extends module
  mqtt: TITLE varchar(255) NOT NULL DEFAULT ''
  mqtt: LOCATION_ID int(10) NOT NULL DEFAULT '0'
  mqtt: UPDATED datetime
- mqtt: VALUE varchar(255) NOT NULL DEFAULT ''
+ mqtt: VALUE varchar(1024) NOT NULL DEFAULT ''
  mqtt: PATH varchar(255) NOT NULL DEFAULT ''
  mqtt: PATH_WRITE varchar(255) NOT NULL DEFAULT ''
  mqtt: REPLACE_LIST varchar(255) NOT NULL DEFAULT ''


### PR DESCRIPTION
If used Tasmota firmware, there may be error 'Data too long for column 'VALUE' at row 1'. This fix only for new installation.