### PR TITLE
Update mqtt.class.php

### DIFF
--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -396,7 +396,7 @@ class mqtt extends module
             }
             if ($rec['LINKED_OBJECT'] && $rec['LINKED_METHOD'] &&
              !(strtolower($rec['LINKED_PROPERTY'])=='status' && strtolower($rec['LINKED_METHOD'])=='switch')) {
-                callMethod($rec['LINKED_OBJECT'] . '.' . $rec['LINKED_METHOD'], array('VALUE'=>$rec['VALUE'],'OLD_VALUE'=>$old_value));
+                callMethod($rec['LINKED_OBJECT'] . '.' . $rec['LINKED_METHOD'], array('NEW_VALUE'=>$rec['VALUE'],'OLD_VALUE'=>$old_value));
             }
 
         }

--- a/modules/mqtt/mqtt.class.php
+++ b/modules/mqtt/mqtt.class.php
@@ -396,7 +396,7 @@ class mqtt extends module
             }
             if ($rec['LINKED_OBJECT'] && $rec['LINKED_METHOD'] &&
              !(strtolower($rec['LINKED_PROPERTY'])=='status' && strtolower($rec['LINKED_METHOD'])=='switch')) {
-                callMethod($rec['LINKED_OBJECT'] . '.' . $rec['LINKED_METHOD'], array('NEW_VALUE'=>$rec['VALUE'],'OLD_VALUE'=>$old_value));
+                callMethod($rec['LINKED_OBJECT'] . '.' . $rec['LINKED_METHOD'], array('VALUE'=>$rec['VALUE'],'NEW_VALUE'=>$rec['VALUE'],'OLD_VALUE'=>$old_value));
             }
 
         }


### PR DESCRIPTION
Вместо $params['VALUE'] будет передаваться стандарное  общепринятое $params['NEW_VALUE'] при привязке метода объекта к топику.